### PR TITLE
support sub-second FS watcher delay

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -169,6 +169,13 @@ func (f *FolderConfiguration) DeviceIDs() []protocol.DeviceID {
 	return deviceIDs
 }
 
+func (f *FolderConfiguration) FSWatcherDelay() time.Duration {
+	if f.FSWatcherDelayS >= 0 {
+		return f.FSWatcherDelay() * time.Second
+	}
+	return time.Second / (-f.FSWatcherDelay())
+}
+
 func (f *FolderConfiguration) prepare(myID protocol.DeviceID, existingDevices map[protocol.DeviceID]bool) {
 	// Ensure that
 	// - any loose devices are not present in the wrong places
@@ -186,11 +193,6 @@ func (f *FolderConfiguration) prepare(myID protocol.DeviceID, existingDevices ma
 		f.RescanIntervalS = MaxRescanIntervalS
 	} else if f.RescanIntervalS < 0 {
 		f.RescanIntervalS = 0
-	}
-
-	if f.FSWatcherDelayS <= 0 {
-		f.FSWatcherEnabled = false
-		f.FSWatcherDelayS = 10
 	}
 
 	if f.Versioning.CleanupIntervalS > MaxRescanIntervalS {

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -437,7 +437,7 @@ func (a *aggregator) CommitConfiguration(from, to config.Configuration) bool {
 
 func (a *aggregator) updateConfig(folderCfg config.FolderConfiguration) {
 	a.notifyDelay = folderCfg.FSWatcherDelay()
-	a.notifyTimeout = notifyTimeout(folderCfg.FSWatcherDelayS)
+	a.notifyTimeout = notifyTimeout(folderCfg.FSWatcherDelay())
 	a.folderCfg = folderCfg
 }
 
@@ -456,16 +456,15 @@ func updateInProgressSet(event events.Event, inProgress map[string]struct{}) {
 // air, they were just considered as a sensible compromise between fast updates and
 // saving resources. For short delays the timeout is 6 times the delay, capped at 1
 // minute. For delays longer than 1 minute, the delay and timeout are equal.
-func notifyTimeout(eventDelayS int) time.Duration {
-	shortDelayS := 10
+func notifyTimeout(eventDelay time.Duration) time.Duration {
+	shortDelay := 10 * time.Second
 	shortDelayMultiplicator := 6
-	longDelayS := 60
-	longDelayTimeout := time.Duration(1) * time.Minute
-	if eventDelayS < shortDelayS {
-		return time.Duration(eventDelayS*shortDelayMultiplicator) * time.Second
+	longDelay := 60 * time.Second
+	if eventDelay < shortDelay {
+		return eventDelay * time.Duration(shortDelayMultiplicator)
 	}
-	if eventDelayS < longDelayS {
-		return longDelayTimeout
+	if eventDelay < longDelay {
+		return longDelay
 	}
-	return time.Duration(eventDelayS) * time.Second
+	return eventDelay
 }

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -436,7 +436,7 @@ func (a *aggregator) CommitConfiguration(from, to config.Configuration) bool {
 }
 
 func (a *aggregator) updateConfig(folderCfg config.FolderConfiguration) {
-	a.notifyDelay = time.Duration(folderCfg.FSWatcherDelayS) * time.Second
+	a.notifyDelay = folderCfg.FSWatcherDelay()
 	a.notifyTimeout = notifyTimeout(folderCfg.FSWatcherDelayS)
 	a.folderCfg = folderCfg
 }


### PR DESCRIPTION
To preserve protocol compatibility, simply treat negative `FSWatcherDelayS` values as microseconds instead, whereas previously they were simply ignored and replaced with a default value.