### PR TITLE
Fix panic in processUpdate

### DIFF
--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -178,7 +178,10 @@ func (c *folderSummaryService) listenForUpdates(ctx context.Context) error {
 		// This loop needs to be fast so we don't miss too many events.
 
 		select {
-		case ev := <-sub.C():
+		case ev, ok := <-sub.C():
+			if !ok {
+				return ctx.Err()
+			}
 			c.processUpdate(ev)
 		case <-ctx.Done():
 			return ctx.Err()

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -180,6 +180,7 @@ func (c *folderSummaryService) listenForUpdates(ctx context.Context) error {
 		select {
 		case ev, ok := <-sub.C():
 			if !ok {
+				<-ctx.Done()
 				return ctx.Err()
 			}
 			c.processUpdate(ev)

--- a/lib/syncthing/auditservice.go
+++ b/lib/syncthing/auditservice.go
@@ -38,7 +38,10 @@ func (s *auditService) Serve(ctx context.Context) error {
 
 	for {
 		select {
-		case ev := <-sub.C():
+		case ev, ok := <-sub.C():
+			if !ok {
+				return ctx.Err()
+			}
 			enc.Encode(ev)
 		case <-ctx.Done():
 			return ctx.Err()

--- a/lib/syncthing/auditservice.go
+++ b/lib/syncthing/auditservice.go
@@ -40,6 +40,7 @@ func (s *auditService) Serve(ctx context.Context) error {
 		select {
 		case ev, ok := <-sub.C():
 			if !ok {
+				<-ctx.Done()
 				return ctx.Err()
 			}
 			enc.Encode(ev)

--- a/lib/syncthing/verboseservice.go
+++ b/lib/syncthing/verboseservice.go
@@ -31,7 +31,10 @@ func (s *verboseService) Serve(ctx context.Context) error {
 	defer sub.Unsubscribe()
 	for {
 		select {
-		case ev := <-sub.C():
+		case ev, ok := <-sub.C():
+			if !ok {
+				return ctx.Err()
+			}
 			formatted := s.formatEvent(ev)
 			if formatted != "" {
 				l.Verboseln(formatted)

--- a/lib/syncthing/verboseservice.go
+++ b/lib/syncthing/verboseservice.go
@@ -33,6 +33,7 @@ func (s *verboseService) Serve(ctx context.Context) error {
 		select {
 		case ev, ok := <-sub.C():
 			if !ok {
+				<-ctx.Done()
 				return ctx.Err()
 			}
 			formatted := s.formatEvent(ev)

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -162,8 +162,10 @@ func (a *aggregator) mainLoop(in <-chan fs.Event, out chan<- []string, cfg confi
 		select {
 		case event := <-in:
 			a.newEvent(event, inProgress)
-		case event := <-inProgressItemSubscription.C():
-			updateInProgressSet(event, inProgress)
+		case event, ok := <-inProgressItemSubscription.C():
+			if ok {
+				updateInProgressSet(event, inProgress)
+			}
 		case <-a.notifyTimer.C:
 			a.actOnTimer(out)
 		case interval := <-a.notifyTimerResetChan:


### PR DESCRIPTION
### Purpose
We see occasional panics in complex tests when the main service's context is closed, causing the events channel to be closed. If this happens during the running of the processUpdate() on the next loop the select may choose either of the branches. If the select processes the events channel closing first, it leads to the following panic, due to the ev.Data being nil (due to ev being an empty struct).
```
github.com/syncthing/syncthing/lib/model.(*folderSummaryService).processUpdate(0xc000150c80, {0x0, 0x0, {0x0, 0x0, 0x0}, 0x0, {0x0, 0x0}})
	/home/runner/go/pkg/mod/github.com/rafttio/syncthing@v0.0.0-20211207134221-cceb0242bfe8/lib/model/folder_summary.go:255 +0x557
github.com/syncthing/syncthing/lib/model.(*folderSummaryService).listenForUpdates(0xc000150c80, {0xf8ebe8, 0xc000424e40})
	/home/runner/go/pkg/mod/github.com/rafttio/syncthing@v0.0.0-20211207134221-cceb0242bfe8/lib/model/folder_summary.go:182 +0x158
github.com/syncthing/syncthing/lib/svcutil.(*service).Serve(0xc000424840, {0xf8ebe8, 0xc000424e40})
	/home/runner/go/pkg/mod/github.com/rafttio/syncthing@v0.0.0-20211207134221-cceb0242bfe8/lib/svcutil/svcutil.go:125 +0x92
github.com/thejerf/suture/v4.(*Supervisor).runService.func2()
	/home/runner/go/pkg/mod/github.com/thejerf/suture/v4@v4.0.1/supervisor.go:551 +0xb0
created by github.com/thejerf/suture/v4.(*Supervisor).runService
	/home/runner/go/pkg/mod/github.com/thejerf/suture/v4@v4.0.1/supervisor.go:539 +0x1cf
```

Solved by checking if the result read from the channel is ok. We return the context error in this case, as that is the real cause here. Open to feedback on that point.

I've searched through the code for additional cases of this bug, and found several. I've fixed them all here.

### Testing

It is difficult to recreate the scenario in which this actually happens, but this is a pretty obvious fix. 

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

